### PR TITLE
fix: Remove console.log

### DIFF
--- a/src/runtime/humblescroll.ts
+++ b/src/runtime/humblescroll.ts
@@ -7,7 +7,6 @@ export default defineNuxtPlugin((nuxtApp) => {
     return
   }
   
-  console.log(useRuntimeConfig())
   const options = useRuntimeConfig().public.humbleScroll
 
   nuxtApp.hook('app:created', () => {


### PR DESCRIPTION
console.log displays certain information which might be confusing when developing with  this plugin. It could also be confusing in production.